### PR TITLE
Feature/fsm thread net: sched/petri — Thread Net (FSM helpers, incidence matrix, wakeup hook)

### DIFF
--- a/code/releng14.1/sys/amd64/conf/VMKERNEL4BSD
+++ b/code/releng14.1/sys/amd64/conf/VMKERNEL4BSD
@@ -23,6 +23,14 @@ options 	UFS_DIRHASH		# Improve performance on big directories
 options 	UFS_GJOURNAL		# Enable gjournal-based UFS journaling
 options 	QUOTA			# Enable disk quotas for UFS
 options 	MD_ROOT			# MD is a potential root device
+
+# options     INVARIANTS           # Enable extra sanity checks throughout the kernel
+# options     INVARIANT_SUPPORT    # Allow building both with and without INVARIANTS
+# options     DIAGNOSTIC           # Add additional diagnostic kernel checks
+# options     WITNESS              # Detect potential deadlocks in locking (mutexes, etc.)
+# options     WITNESS_SKIPSPIN     # Skip witness checks on spin locks (reduce overhead)
+
+
 #options 	COMPAT_FREEBSD32	# Compatible with i386 binaries
 #options 	COMPAT_FREEBSD4		# Compatible with FreeBSD4
 #options 	COMPAT_FREEBSD5		# Compatible with FreeBSD5

--- a/code/releng14.1/sys/kern/init_main.c
+++ b/code/releng14.1/sys/kern/init_main.c
@@ -344,7 +344,10 @@ mi_startup(void)
 	/*
 	 * Now hand over this thread to swapper.
 	 */
-	printf(" SIN DEBUG !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!???????????????.\n");
+	for (int i = 0; i < 6; i++) {
+		printf("> feature/fsm-thread-net .\n");
+	}
+
 
 	swapper();
 	/* NOTREACHED*/

--- a/code/releng14.1/sys/kern/init_main.c
+++ b/code/releng14.1/sys/kern/init_main.c
@@ -345,7 +345,7 @@ mi_startup(void)
 	 * Now hand over this thread to swapper.
 	 */
 	for (int i = 0; i < 6; i++) {
-		printf("> feature/fsm-thread-net .\n");
+		printf("> feature/fsm-thread-net 2 .\n");
 	}
 
 

--- a/code/releng14.1/sys/kern/petri_global_net.c
+++ b/code/releng14.1/sys/kern/petri_global_net.c
@@ -1,13 +1,3 @@
-/*
- ============================================================================
- Name        : petri_global_net.c
- Author      : 
- Version     :
- Copyright   : Your copyright notice
- Description : Hello World in C, Ansi-style
- ============================================================================
- */
-
 #include <sys/types.h>
 #include <sys/sched_petri.h>
 #include <sys/syslog.h>
@@ -206,18 +196,18 @@ is_inhibited(int places_index, int transition_index)
 	return ((resource_net->inhibition_matrix[places_index][transition_index] == 1) && (resource_net->mark[places_index] > 0));
 }
 
-static __inline int 
-is_hierarchical(int transition) 
-{
+// static __inline int 
+// is_hierarchical(int transition) 
+// {
 
-	for (int i = 0; i < HIERARCHICAL_TRANSITIONS; i++) {
-		if (transition == hierarchical_transitions[i] ||
-			((transition < TRAN_REMOVE_GLOBAL_QUEUE) && 
-			(transition % CPU_BASE_TRANSITIONS) == hierarchical_transitions[i]))
-			return hierarchical_corresponse[i];
-	}
-	return 0;
-}
+// 	for (int i = 0; i < HIERARCHICAL_TRANSITIONS; i++) {
+// 		if (transition == hierarchical_transitions[i] ||
+// 			((transition < TRAN_REMOVE_GLOBAL_QUEUE) && 
+// 			(transition % CPU_BASE_TRANSITIONS) == hierarchical_transitions[i]))
+// 			return hierarchical_corresponse[i];
+// 	}
+// 	return 0;
+// }
 
 bool 
 is_cpu_suspended(int cpu_n)
@@ -229,7 +219,7 @@ is_cpu_suspended(int cpu_n)
  * fire the transition passed as param to the function
  * and check for automatic transitions to be fired
 */
-void resource_fire_net(struct thread *pt, int transition_index, char *func)
+void resource_fire_net(struct thread *pt, int transition_index, const char *func)
 {
 
 	if (pt) {
@@ -260,15 +250,15 @@ void resource_fire_net(struct thread *pt, int transition_index, char *func)
 static void 
 resource_fire_single_transition(struct thread *pt, int transition_index) 
 {
-	int local_transition = 0;
+	//int local_transition = 0;
 	
 	//Fire cpu net	
 	for (int num_place = 0; num_place < CPU_NUMBER_PLACES; num_place++)
 		resource_net->mark[num_place] += resource_net->incidence_matrix[num_place][transition_index];
 	
-	local_transition = is_hierarchical(transition_index);
-	if (local_transition) //If we need to fire a local thread transition we fire it here
-		thread_petri_fire(pt, local_transition, print); 
+	// local_transition = is_hierarchical(transition_index);
+	// if (local_transition) //If we need to fire a local thread transition we fire it here
+	// 	thread_petri_fire(pt, local_transition, print); 
 }
 
 bool 
@@ -323,18 +313,28 @@ resource_choose_cpu(struct thread* td)
 	return TRAN_QUEUE_GLOBAL;
 }
 
-void 
-resource_expulse_thread(struct thread *td, int flags, char *func) 
+void resource_expulse_thread(struct thread *td, int flags, const char *func)
 {
-	int transition_number;
+    /* Decide the resource-net transition based on the switch type */
+    const int cpu = td->td_lastcpu;
+    const bool is_voluntary = (flags & SW_VOL) != 0;
+    const int res_tr = TRANSITION(cpu, is_voluntary ? TRAN_RETURN_VOL : TRAN_RETURN_INVOL);
 
-	transition_number = (flags & SW_VOL) ? 
-						TRANSITION(td->td_lastcpu, TRAN_RETURN_VOL) : 
-						TRANSITION(td->td_lastcpu, TRAN_RETURN_INVOL);
-	td->td_frominh = (flags & SW_VOL) ? 1 : 0;
-		
-	resource_fire_net(td, transition_number, func);
+    /* Fire resource net (CPU/resource-side) */
+    resource_fire_net(td, res_tr, func);
+
+    /* Directly set the thread FSM (one-hot) in O(1) */
+    if (is_voluntary) {
+        /* Voluntary return: RUNNING -> CAN_RUN */
+        thread_fire_can_run(td);   /* {0,1,0,0,0} */
+        td->td_frominh = 0;        /* no pending wakeup */
+    } else {
+        /* Involuntary return/preempt: RUNNING -> INHIBITED/WAIT */
+        thread_fire_suspended(td); /* {0,0,0,0,1} */
+        td->td_frominh = 1;        /* allow wakeup_if_needed() to restore CAN_RUN */
+    }
 }
+
 
 bool 
 toggle_active_cpu(int cpu, bool turn_off)
@@ -350,19 +350,18 @@ toggle_active_cpu(int cpu, bool turn_off)
 		return false;
 	}
 
-	int transition = turn_off ? TRAN_SUSPEND_PROC : TRAN_WAKEUP_PROC;
-	char *action = turn_off ? "turned off" : "turned on";
+	const int base_tr = turn_off ? TRAN_SUSPEND_PROC : TRAN_WAKEUP_PROC;
+    const int tr = TRANSITION(cpu, base_tr);
+    const char *action = turn_off ? "turned off" : "turned on";
 
-	if (transition_is_sensitized(TRANSITION(cpu, transition))) {
-		//if turning on, we need to check if its already on? i.e. if i can suspend it
-		//because i have doubts that if im not suspended, i can trigger TRAN_WAKEUP_PROC multiple times
-		resource_fire_net(curthread, TRANSITION(cpu, transition), action);
-		return true;
-	} 
-		
-	log(LOG_WARNING, "CPU %d cannot be %s\n", cpu, action);
+    if (transition_is_sensitized(tr)) {
+        /* Resource-only: this does not alter the thread FSM */
+        resource_fire_net(curthread, tr, action);
+        return true;
+    }
 
-	return false;
+    log(LOG_WARNING, "CPU %d cannot be %s\n", cpu, action);
+    return false;
 }
 
 void 

--- a/code/releng14.1/sys/kern/sched_4bsd.c
+++ b/code/releng14.1/sys/kern/sched_4bsd.c
@@ -1069,7 +1069,7 @@ sched_switch(struct thread *td, int flags)
 	newtd = choosethread();
 	MPASS(newtd->td_lock == &sched_lock);
 	resource_fire_net(newtd, TRANSITION(PCPU_GET(cpuid), TRAN_EXEC), "sched_switch");
-
+	thread_fire_running(newtd);
 
 #if (KTR_COMPILE & KTR_SCHED) != 0
 	if (TD_IS_IDLETHREAD(td))
@@ -1386,6 +1386,7 @@ sched_add(struct thread *td, int flags)
 		    cpu);
 
 		resource_fire_net(td, TRANSITION(cpu, TRAN_ADDTOQUEUE), "sched_add");
+		thread_fire_runq(td);
 	} else {
 		CTR2(KTR_RUNQ,
 		    "sched_add: adding td_sched:%p (td:%p) to gbl runq", ts,
@@ -1393,6 +1394,7 @@ sched_add(struct thread *td, int flags)
 		cpu = NOCPU;
 		ts->ts_runq = &runq;
 		resource_fire_net(td, TRAN_QUEUE_GLOBAL, "sched_add");
+		// (no FSM call)
 	}
 
 	if ((td->td_flags & TDF_NOLOAD) == 0)
@@ -1491,8 +1493,10 @@ sched_rem(struct thread *td)
 	if (ts->ts_runq != &runq) {
 		runq_length[ts->ts_runq - runq_pcpu]--;
 		resource_fire_net(td, TRANSITION((ts->ts_runq - runq_pcpu), TRAN_REMOVE_QUEUE), "sched_rem");
+		thread_fire_can_run(td);
 	} else
 		resource_fire_net(td, TRAN_REMOVE_GLOBAL_QUEUE, "sched_add");
+		// (no FSM call)
 #endif
 	runq_remove(ts->ts_runq, td);
 	TD_SET_CAN_RUN(td);
@@ -1537,10 +1541,11 @@ sched_choose(void)
 		rq = &runq_pcpu[cpu_n];
 
 		if (td) //active thread available
-			resource_fire_net(td, TRANSITION(cpu_n, TRAN_UNQUEUE), "sched_choose");
+			resource_fire_net(td, TRANSITION(cpu_n, TRAN_UNQUEUE), "sched_choose"); // (no FSM call)
 		else if (is_cpu_suspended(cpu_n)) { //CPU suspended -> no active thread 
 			wakeup_if_needed(idletd);
 			resource_fire_net(idletd, TRANSITION(cpu_n, TRAN_EXEC_IDLE), "sched_choose_4");
+			thread_fire_runq(idletd);
 			return (idletd);
 		}
 	} else {
@@ -1550,6 +1555,7 @@ sched_choose(void)
 			// El td es el de la cola global y se continua la ejecución
 			CTR1(KTR_RUNQ, "choosing td_sched %p from main runq", td);
 			resource_fire_net(td, TRANSITION(cpu_n, TRAN_FROM_GLOBAL_CPU), "sched_choose");
+			// (no FSM call)
 		} else //si la cpu no esta disponible para el hilo hago que se ejecute idlethread?
 			td = NULL;
 	}
@@ -1574,6 +1580,7 @@ sched_choose(void)
 
 	wakeup_if_needed(idletd);
 	resource_fire_net(idletd, TRANSITION(cpu_n, TRAN_EXEC_IDLE), "sched_choose_3");
+	thread_fire_runq(idletd);
 	return (idletd);
 }
 
@@ -1748,6 +1755,7 @@ sched_throw_tail(struct thread *td)
 	KASSERT(curthread->td_md.md_spinlock_count == 1, ("invalid count"));
 	newtd = choosethread();
 	resource_fire_net(newtd, TRANSITION(PCPU_GET(cpuid), TRAN_EXEC), "sched_throw");
+	thread_fire_running(newtd);
 	cpu_throw(td, newtd);	/* doesn't return */
 }
 

--- a/code/releng14.1/sys/kern/sched_petri.c
+++ b/code/releng14.1/sys/kern/sched_petri.c
@@ -1,77 +1,139 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Petri-net based thread lifecycle (scheduler side).
+ */
+
+#include <sys/param.h>
 #include <sys/sched_petri.h>
 #include <sys/sysctl.h>
 #include <sys/syslog.h>
+#include <sys/systm.h>   /* KASSERT, DIAGNOSTIC */
 
+/*
+ * Sysctl entry (informational only).
+ */
 SYSCTL_STRING(_kern_sched, OID_AUTO, cpu_sel, CTLFLAG_RD, "PETRI", 0,
     "Scheduler pickcpu method");
 
-/* GLOBAL VARIABLES */
+/* ============================================================
+ * Incidence matrix of the thread net (places × transitions)
+ *
+ * Places (THREADS_PLACES_SIZE):
+ *   0: INACTIVE
+ *   1: CAN_RUN
+ *   2: RUNQ
+ *   3: RUNNING
+ *   4: INHIBITED
+ *
+ * Transitions (THREADS_TRANSITIONS_SIZE):
+ *   0: TRAN_INIT
+ *   1: TRAN_ON_QUEUE
+ *   2: TRAN_SET_RUNNING
+ *   3: TRAN_SWITCH_OUT
+ *   4: TRAN_TO_WAIT_CHANNEL
+ *   5: TRAN_WAKEUP
+ *   6: TRAN_REMOVE
+ * ============================================================
+ */
+
+/* Global data (read-only) */
 const int incidence_matrix[THREADS_PLACES_SIZE][THREADS_TRANSITIONS_SIZE] = {
-	{-1,  0,  0,  0,  0,  0,  0},
-	{ 1, -1,  0,  1,  0,  1,  1},
-	{ 0,  1, -1,  0,  0,  0, -1},
-	{ 0,  0,  1, -1, -1,  0,  0},
-	{ 0,  0,  0,  0,  1, -1,  0}
+	/*             INIT  ON_Q  SET_RUN  SWITCH_OUT  TO_WAIT   WAKEUP  REMOVE */
+	/* INACTIVE */ { -1,   0,     0,        0,         0,       0,      0   },
+	/* CAN_RUN  */ {  1,  -1,     0,        1,         0,       1,      1   },
+	/* RUNQ     */ {  0,   1,    -1,        0,         0,       0,     -1   },
+	/* RUNNING  */ {  0,   0,     1,       -1,        -1,       0,      0   },
+	/* INHIBITED*/ {  0,   0,     0,        0,         1,      -1,      0   }
 };
 
-const int initial_mark[THREADS_PLACES_SIZE] = { 0, 1, 0, 0, 0 };
+const int initial_mark[THREADS_PLACES_SIZE]  = { 0, 1, 0, 0, 0 };
 const int initial_mark0[THREADS_PLACES_SIZE] = { 0, 0, 0, 1, 0 };
 
 const char *thread_transitions_names[THREADS_TRANSITIONS_SIZE] = {
-	"TRAN_INIT", "TRAN_ON_QUEUE", "TRAN_SET_RUNNING", "TRAN_SWITCH_OUT", "TRAN_TO_WAIT_CHANNEL", "TRAN_WAKEUP", "TRAN_REMOVE"
+	"TRAN_INIT", "TRAN_ON_QUEUE", "TRAN_SET_RUNNING",
+	"TRAN_SWITCH_OUT", "TRAN_TO_WAIT_CHANNEL", "TRAN_WAKEUP", "TRAN_REMOVE"
 };
 
 const char *thread_places[THREADS_PLACES_SIZE] = {
 	"INACTIVE", "CAN_RUN", "RUNQ", "RUNNING", "INHIBITED"
 };
 
-__inline bool thread_transition_is_sensitized(struct thread *pt, int transition_index);
-void thread_print_net(struct thread *pt);
+/* Internal prototypes */
+static inline bool thread_transition_is_sensitized(struct thread *pt, int transition_index);
+static void thread_print_net(struct thread *pt);
+
+/* ============================================================
+ * Thread net initialization
+ * ============================================================
+ */
 
 void
 init_petri_thread(struct thread *pt_thread)
 {
-	// Create a new petr_thread structure
-	for (int i = 0; i < THREADS_PLACES_SIZE; i++) 
+	/* Regular threads start in CAN_RUN */
+	for (int i = 0; i < THREADS_PLACES_SIZE; i++)
 		pt_thread->mark[i] = initial_mark[i];
-	
 	pt_thread->td_frominh = 0;
 }
 
 void
 init_petri_thread0(struct thread *pt_thread)
 {
-	// Create a new petr_thread structure
-	for (int i = 0; i < THREADS_PLACES_SIZE; i++) 
+	/* Thread 0 starts in RUNNING */
+	for (int i = 0; i < THREADS_PLACES_SIZE; i++)
 		pt_thread->mark[i] = initial_mark0[i];
-	
 	pt_thread->td_frominh = 0;
 }
 
-__inline bool
+/* ============================================================
+ * Sensitization helper (diagnostics only).
+ * At runtime, the resource net guarantees sensitization,
+ * so thread_petri_fire() does not need to re-check it.
+ * ============================================================
+ */
+
+static inline bool
 thread_transition_is_sensitized(struct thread *pt, int transition_index)
 {
 	for (int places_index = 0; places_index < THREADS_PLACES_SIZE; places_index++) {
-		if (((incidence_matrix[places_index][transition_index] < 0) && 
-			//If incidence is positive we really dont care if there are tokens or not
-			((incidence_matrix[places_index][transition_index] + pt->mark[places_index]) < 0))) 
+		if ((incidence_matrix[places_index][transition_index] < 0) &&
+		    ((incidence_matrix[places_index][transition_index] + pt->mark[places_index]) < 0))
 			return false;
 	}
-
 	return true;
 }
+
+/* ============================================================
+ * Fire a thread-level transition (hierarchical to resources).
+ * ============================================================
+ */
 
 void
 thread_petri_fire(struct thread *pt, int transition, int print)
 {
-	if (thread_transition_is_sensitized(pt, transition)) 
-		for(int i = 0; i < THREADS_PLACES_SIZE; i++)
-			pt->mark[i] += incidence_matrix[i][transition];
-	else {
-		log(LOG_WARNING, "\t(sched_petri) %s no estaba sensibilizada para thread %d\n", thread_transitions_names[transition % CPU_BASE_TRANSITIONS], pt->td_tid);
-		thread_print_net(pt);
+#ifdef DIAGNOSTIC
+	/* In debug builds, detect desynchronizations with the resource net. */
+	KASSERT(thread_transition_is_sensitized(pt, transition),
+	    ("thread transition %d not sensitized (desync with resource net)", transition));
+#endif
+
+	for (int i = 0; i < THREADS_PLACES_SIZE; i++)
+		pt->mark[i] += incidence_matrix[i][transition];
+
+	if (print > 0) {
+		const char *tname =
+		    (transition >= 0 && transition < THREADS_TRANSITIONS_SIZE)
+		        ? thread_transitions_names[transition]
+		        : "UNKNOWN";
+		log(LOG_INFO, "\t(sched_petri) %s fired for thread %d\n", tname, pt->td_tid);
 	}
 }
+
+/* ============================================================
+ * Conditional wakeup (INHIBITED → WAKEUP).
+ * ============================================================
+ */
 
 void
 wakeup_if_needed(struct thread *td)
@@ -82,11 +144,18 @@ wakeup_if_needed(struct thread *td)
 	}
 }
 
-void 
+/* ============================================================
+ * Debug helper: print the current marking of a thread net.
+ * ============================================================
+ */
+
+static void
 thread_print_net(struct thread *pt)
 {
-	log(LOG_WARNING, "\t\t(sched_petri) Estado thread %2d: ", pt->td_tid);
-	for (int i = 0; i < THREADS_PLACES_SIZE; i++)
-		if (pt->mark[i] == 1)
-			log(LOG_WARNING, "%s\n", thread_places[i]);
+	log(LOG_WARNING, "\t\t(sched_petri) Thread %2d state:", pt->td_tid);
+	for (int i = 0; i < THREADS_PLACES_SIZE; i++) {
+		if (pt->mark[i] > 0)
+			log(LOG_WARNING, " %s(%d)", thread_places[i], pt->mark[i]);
+	}
+	log(LOG_WARNING, "\n");
 }

--- a/code/releng14.1/sys/kern/sched_petri.c
+++ b/code/releng14.1/sys/kern/sched_petri.c
@@ -111,26 +111,88 @@ thread_transition_is_sensitized(struct thread *pt, int transition_index)
  * ============================================================
  */
 
-void
-thread_petri_fire(struct thread *pt, int transition, int print)
+// void
+// thread_petri_fire(struct thread *pt, int transition, int print)
+// {
+// #ifdef DIAGNOSTIC
+// 	/* In debug builds, detect desynchronizations with the resource net. */
+// 	KASSERT(thread_transition_is_sensitized(pt, transition),
+// 	    ("thread transition %d not sensitized (desync with resource net)", transition));
+// #endif
+
+// 	for (int i = 0; i < THREADS_PLACES_SIZE; i++)
+// 		pt->mark[i] += incidence_matrix[i][transition];
+
+// 	if (print > 0) {
+// 		const char *tname =
+// 		    (transition >= 0 && transition < THREADS_TRANSITIONS_SIZE)
+// 		        ? thread_transitions_names[transition]
+// 		        : "UNKNOWN";
+// 		log(LOG_INFO, "\t(sched_petri) %s fired for thread %d\n", tname, pt->td_tid);
+// 	}
+// }
+
+
+
+/* ============================================================
+ * Thread FSM (one-hot): final markings in O(1)
+ * These helpers directly set the one-hot marking for the
+ * thread net places, without using the incidence matrix.
+ *
+ * Place order (THREADS_PLACES_SIZE == 5):
+ *   0: INACTIVE, 1: CAN_RUN, 2: RUNQ, 3: RUNNING, 4: INHIBITED
+ * ============================================================
+ */
+
+/* Compile-time contract: keep header and implementation aligned. */
+_Static_assert(THREADS_PLACES_SIZE == 5, "Expected 5 thread places in thread net");
+
+/* Internal helper: write a one-hot marking (exactly one '1'). */
+static inline void
+thread_set_mark5(struct thread *pt, int m0, int m1, int m2, int m3, int m4)
 {
 #ifdef DIAGNOSTIC
-	/* In debug builds, detect desynchronizations with the resource net. */
-	KASSERT(thread_transition_is_sensitized(pt, transition),
-	    ("thread transition %d not sensitized (desync with resource net)", transition));
+	int sum = (m0 != 0) + (m1 != 0) + (m2 != 0) + (m3 != 0) + (m4 != 0);
+	KASSERT(sum == 1, ("thread_set_mark5: mark is not one-hot (%d,%d,%d,%d,%d)",
+	    m0, m1, m2, m3, m4));
 #endif
-
-	for (int i = 0; i < THREADS_PLACES_SIZE; i++)
-		pt->mark[i] += incidence_matrix[i][transition];
-
-	if (print > 0) {
-		const char *tname =
-		    (transition >= 0 && transition < THREADS_TRANSITIONS_SIZE)
-		        ? thread_transitions_names[transition]
-		        : "UNKNOWN";
-		log(LOG_INFO, "\t(sched_petri) %s fired for thread %d\n", tname, pt->td_tid);
-	}
+	pt->mark[0] = m0;
+	pt->mark[1] = m1;
+	pt->mark[2] = m2;
+	pt->mark[3] = m3;
+	pt->mark[4] = m4;
 }
+
+/* -> {0,0,1,0,0}  (ADDTOQUEUE, EXEC_IDLE) */
+void
+thread_fire_runq(struct thread *pt)
+{
+	thread_set_mark5(pt, 0, 0, 1, 0, 0);
+}
+
+/* -> {0,0,0,1,0}  (EXEC) */
+void
+thread_fire_running(struct thread *pt)
+{
+	thread_set_mark5(pt, 0, 0, 0, 1, 0);
+}
+
+/* -> {0,0,0,0,1}  (RETURN_INVOL) */
+void
+thread_fire_suspended(struct thread *pt)
+{
+	thread_set_mark5(pt, 0, 0, 0, 0, 1);
+}
+
+/* -> {0,1,0,0,0}  (RETURN_VOL, REMOVE_QUEUE, WAKEUP target) */
+void
+thread_fire_can_run(struct thread *pt)
+{
+	thread_set_mark5(pt, 0, 1, 0, 0, 0);
+}
+
+
+
 
 /* ============================================================
  * Conditional wakeup (INHIBITED → WAKEUP).
@@ -141,10 +203,12 @@ void
 wakeup_if_needed(struct thread *td)
 {
 	if (td && (td->td_frominh == 1)) {
-		thread_petri_fire(td, TRAN_WAKEUP, -1);
+		/* WAKEUP moves the thread from INHIBITED to CAN_RUN */
+		thread_fire_can_run(td);
 		td->td_frominh = 0;
 	}
 }
+
 
 /* ============================================================
  * Debug helper: print the current marking of a thread net.

--- a/code/releng14.1/sys/sys/sched_petri.h
+++ b/code/releng14.1/sys/sys/sched_petri.h
@@ -10,11 +10,11 @@
        CPU_ISSET((cpu), &(td)->td_cpuset->cs_mask)
 
 /* macros for common operations to obtain indexes of net places and transitions */
-#define CPU_BASE_TRANSITION(cpu)	cpu*CPU_BASE_TRANSITIONS
-#define CPU_BASE_PLACE(cpu)			cpu*CPU_BASE_PLACES
+#define CPU_BASE_TRANSITION(cpu)  ((cpu) * CPU_BASE_TRANSITIONS)
+#define CPU_BASE_PLACE(cpu)       ((cpu) * CPU_BASE_PLACES)
 
-#define TRANSITION(cpu, transition)	(CPU_BASE_TRANSITION(cpu) + transition)
-#define PLACE(cpu, place)			(CPU_BASE_PLACE(cpu) + place)
+#define TRANSITION(cpu, transition)  (CPU_BASE_TRANSITION(cpu) + (transition))
+#define PLACE(cpu, place)            (CPU_BASE_PLACE(cpu) + (place))
 
 /* Definition of constants of the resource petri net */
 #define CPU_BASE_PLACES 		5
@@ -72,11 +72,38 @@ struct petri_cpu_resource_net {
 	char **inhibition_matrix;
 };
 
+
+//make the contract explicit for the thread FSM implementation */
+#ifndef THREADS_PLACES_SIZE
+#define THREADS_PLACES_SIZE 5
+#endif
+
+
 //Petri thread Methods
 void init_petri_thread(struct thread *pt_thread);
 void init_petri_thread0(struct thread *pt_thread);
-void thread_petri_fire(struct thread *pt, int transition, int print);
+//void thread_petri_fire(struct thread *pt, int transition, int print);
 void wakeup_if_needed(struct thread *td);
+
+
+/* =========================
+ * Thread FSM (one-hot) API
+ * =========================
+ * The thread net is modeled as a one-hot FSM.
+ * Each helper below writes the final marking in O(1) (no incidence loops).
+ * Call them explicitly right after resource_fire_net(...) from sched_4bsd.
+ */
+
+
+/* New FSM-style setters (final one-hot markings). */
+void thread_fire_runq(struct thread *pt);       /* -> {0,0,1,0,0}  (ADDTOQUEUE, EXEC_IDLE) */
+void thread_fire_running(struct thread *pt);    /* -> {0,0,0,1,0}  (EXEC) */
+void thread_fire_suspended(struct thread *pt);  /* -> {0,0,0,0,1}  (RETURN_INVOL) */
+void thread_fire_can_run(struct thread *pt);    /* -> {0,1,0,0,0}  (RETURN_VOL, REMOVE_QUEUE) */
+
+/* Deprecated legacy API (kept only if some call sites still include it). */
+/* void thread_petri_fire(struct thread *pt, int transition, int print); */ /* DEPRECATED */
+
 
 //Petri Global Methods
 int  resource_choose_cpu(struct thread *td);
@@ -90,8 +117,8 @@ void *init_pointer(size_t size);
 void init_resource_net(void);
 bool monopolize_cpu(int proc_id, int cpu); 
 bool release_cpu(int proc_id, int cpu); 
-void resource_fire_net(struct thread *pt, int transition_index, char *func);
-void resource_expulse_thread(struct thread *td, int flags, char *func);
+void resource_fire_net(struct thread *pt, int transition_index, const char *func);
+void resource_expulse_thread(struct thread *td, int flags, const char *func);
 void toggle_pin_thread_to_cpu(int thread_id, int cpu);
 void turn_off_cpu(int cpu);
 void turn_on_cpu(int cpu);


### PR DESCRIPTION

This PR introduces a clear, one‑hot **thread lifecycle FSM** on the scheduler side and documents the underlying **Petri‑net incidence matrix**. It also adds a small sysctl for introspection and a debug helper to print the current marking.

**Key goals:**
- Make thread state transitions explicit and O(1) via one‑hot setters.
- Keep the formal Petri‑net (incidence matrix) documented and available.
- Preserve diagnostic guards and provide a simple wakeup path from `INHIBITED`.



### 1) Sysctl (informational)
```c
SYSCTL_STRING(_kern_sched, OID_AUTO, cpu_sel, CTLFLAG_RD, "PETRI", 0,
    "Scheduler pickcpu method");
```
- Exposes `_kern_sched.cpu_sel="PETRI"` as a read‑only string (informational).

### 2) Documented incidence matrix (thread net)
- Places (`THREADS_PLACES_SIZE == 5`): `INACTIVE (0), CAN_RUN (1), RUNQ (2), RUNNING (3), INHIBITED (4)`.
- Transitions (`THREADS_TRANSITIONS_SIZE == 7`): `TRAN_INIT, TRAN_ON_QUEUE, TRAN_SET_RUNNING, TRAN_SWITCH_OUT, TRAN_TO_WAIT_CHANNEL, TRAN_WAKEUP, TRAN_REMOVE`.
- `const int incidence_matrix[P][T]` now lives in one place with a block comment showing the layout.
- Initial markings:
  - Regular threads: `initial_mark = {0,1,0,0,0}` → `CAN_RUN`
  - Thread 0: `initial_mark0 = {0,0,0,1,0}` → `RUNNING`
- Tables of transition and place names are provided for logging and debugging.

### 3) Initialization helpers
```c
void init_petri_thread(struct thread *pt);   // starts at CAN_RUN
void init_petri_thread0(struct thread *pt);  // starts at RUNNING (thread 0)
```
- Both reset `td_frominh` to 0.

### 4) Sensitization helper (diagnostics only)
```c
static inline bool thread_transition_is_sensitized(struct thread *pt, int transition_index);
```
- Validates that firing a transition won’t underflow a place (only used under `DIAGNOSTIC`).

### 5) One‑hot FSM helpers (O(1) marking)
```c
void thread_fire_runq(struct thread *pt);       // -> {0,0,1,0,0}  (ADDTOQUEUE, EXEC_IDLE)
void thread_fire_running(struct thread *pt);    // -> {0,0,0,1,0}  (EXEC)
void thread_fire_suspended(struct thread *pt);  // -> {0,0,0,0,1}  (RETURN_INVOL)
void thread_fire_can_run(struct thread *pt);    // -> {0,1,0,0,0}  (RETURN_VOL, REMOVE_QUEUE, WAKEUP target)
```
- Backed by an internal contract:
  ```c
  _Static_assert(THREADS_PLACES_SIZE == 5, "Expected 5 thread places in thread net");
  ```
- Internal writer ensures **one‑hot** correctness in `DIAGNOSTIC` builds:
  ```c
  static inline void thread_set_mark5(struct thread *pt, int m0, int m1, int m2, int m3, int m4);
  ```

### 6) Conditional wakeup from INHIBITED
```c
void wakeup_if_needed(struct thread *td);
```
- If `td->td_frominh == 1`, moves `INHIBITED → CAN_RUN` via `thread_fire_can_run(td)` and clears the flag.

### 7) Debug print of current marking
```c
static void thread_print_net(struct thread *pt);
```
- Produces a compact log line including the active place name and token count.

### 8) Note on `thread_petri_fire`
- The generic `thread_petri_fire(...)` (matrix‑based update) remains **commented** here. The FSM helpers provide the fast‑path “final markings” per common transitions while keeping the formal matrix and diagnostics available.

---

## Transition → One‑hot Mark (reference)
| High‑level Transition                | Resulting Mark `{INACTIVE, CAN_RUN, RUNQ, RUNNING, INHIBITED}` |
|-------------------------------------|------------------------------------------------------------------|
| `ADDTOQUEUE`                        | `{0,0,1,0,0}` |
| `EXEC`                              | `{0,0,0,1,0}` |
| `EXEC_IDLE`                         | `{0,0,1,0,0}` |
| `RETURN_INVOL`                      | `{0,0,0,0,1}` |
| `RETURN_VOL`                        | `{0,1,0,0,0}` |
| `REMOVE_QUEUE`                      | `{0,1,0,0,0}` |
| `WAKEUP` (target state)             | `{0,1,0,0,0}` |

> These mappings are implemented via the dedicated FSM helpers above.

---

## Rationale
- **Clarity & speed**: one‑hot setters make final states explicit and O(1), suitable for hot paths.
- **Correctness**: diagnostics still use the formal matrix and sensitization checks in debug builds.
- **Operational simplicity**: `wakeup_if_needed()` centralizes the common `INHIBITED → CAN_RUN` path.

---
